### PR TITLE
Fix : Saved color image does not include RGB text overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
 venv
 selected_color.png
+selected_color_with_text.png
 __pycache__

--- a/palette.py
+++ b/palette.py
@@ -31,7 +31,8 @@ while(True):
     if key == 27:
         break
     elif key == ord('s'):
+        cv2.imwrite("selected_color_with_text.png",img)
         cv2.imwrite("selected_color.png",color_img)
-        print("Saved current color as 'selected_color.png'")
+        print("Saved: 'selected_color.png' (without text) & 'selected_color_with_text.png' (with text)")
 
 cv2.destroyAllWindows()


### PR DESCRIPTION
# PULL REQUEST 
Title : Fix : Saved color image does not include RGB text overlay

Closes #25 

# 📌 Description
This pull request includes a small change to the `palette.py` file. The change saves an additional image with text when the 's' key is pressed and updates the corresponding print statement to reflect this.

* `palette.py`: Added a new image save operation to store an image with text as `selected_color_with_text.png`, and updated the print statement to indicate both images saved.


# 📷 Screenshots
Without text
![selected_color](https://github.com/user-attachments/assets/577abf5b-6c3a-4ac4-8cff-f6eeffe0566f)

With text
![selected_color_with_text](https://github.com/user-attachments/assets/ff05501c-f382-4610-90d4-5b9239d95dad)



**Additional context(if any)**

# 🏆Are you contributing under any open-source program?
Yes
