### PR TITLE
fix : Unmanaged Window Proliferation and Z-Order Issues

### DIFF
--- a/img_segment.py
+++ b/img_segment.py
@@ -46,7 +46,7 @@ except Exception as e:
     exit(1)
 
 # Create a named window FIRST
-cv2.namedWindow("Tracking")
+cv2.namedWindow("Tracking",cv2.WINDOW_AUTOSIZE)
 
 # Function to handle trackbar updates
 def nothing(x):

--- a/img_segment.py
+++ b/img_segment.py
@@ -46,7 +46,7 @@ except Exception as e:
     exit(1)
 
 # Create a named window FIRST
-cv2.namedWindow("Tracking",cv2.WINDOW_AUTOSIZE)
+cv2.namedWindow("Tracking",cv2.WINDOW_NORMAL)
 
 # Function to handle trackbar updates
 def nothing(x):
@@ -56,6 +56,7 @@ def nothing(x):
 cv2.imshow("Tracking", np.zeros((100, 600, 3), np.uint8))
 
 # Create trackbars
+cv2.setWindowProperty("Tracking", cv2.WND_PROP_TOPMOST, 1)
 cv2.createTrackbar("LH", "Tracking", 0, 179, nothing)
 cv2.createTrackbar("LS", "Tracking", 0, 255, nothing)
 cv2.createTrackbar("LV", "Tracking", 0, 255, nothing)
@@ -63,6 +64,8 @@ cv2.createTrackbar("UH", "Tracking", 179, 179, nothing)
 cv2.createTrackbar("US", "Tracking", 255, 255, nothing)
 cv2.createTrackbar("UV", "Tracking", 255, 255, nothing)
 cv2.createTrackbar("K_Size", "Tracking", 1, 30, nothing)
+
+create_display_windows(input_type='img')
 
 def prompt_filename(title, default_name):
     root = tk.Tk()

--- a/segment.py
+++ b/segment.py
@@ -37,11 +37,11 @@ if not cap.isOpened():
 
 # Create display windows to show results
 cv2.namedWindow("Tracking", cv2.WINDOW_NORMAL)  # Ensure "Tracking" window is created
-cv2.namedWindow("Original", cv2.WINDOW_NORMAL)  # Window to display original frame
 
 # Create trackbars for real-time tuning of segmentation parameters
 def create_trackbars(window_name):
     # Trackbars to adjust lower and upper bounds of the color range
+    cv2.resizeWindow("Tracking", 500, 300)
     cv2.createTrackbar("LH", window_name, 0, 179, nothing)  # Lower Hue
     cv2.createTrackbar("LS", window_name, 0, 255, nothing)  # Lower Saturation
     cv2.createTrackbar("LV", window_name, 0, 255, nothing)  # Lower Value
@@ -53,13 +53,12 @@ def create_trackbars(window_name):
 def nothing(x):
     pass  # Placeholder for the trackbar callback (does nothing)
 
+create_display_windows(input_type='video')
+
 # Create the trackbars
 create_trackbars("Tracking")
 
-# Ensure the trackbars and window are initialized properly before the loop
-cv2.waitKey(1)  # This ensures the window and trackbars are fully initialized
-
-cv2.resizeWindow("Tracking", 500, 10)
+cv2.setWindowProperty("Tracking", cv2.WND_PROP_TOPMOST,1)
 
 # Start an infinite loop for video processing
 while True:


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Unmanaged Window Proliferation and Z-Order Issues

Closes #59
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
This pull request includes updates to the `img_segment.py` and `segment.py` files to improve the handling of video frame resizing and window creation. The most important changes include modifying the window creation to use auto-sizing, adding resizing of masks and results, and removing redundant code for frame reading and processing.

Improvements to window creation and resizing:

* [`img_segment.py`](diffhunk://#diff-edb8f3b129c3b13bb610448147a08d7f4a0807c43e57f02e5e75f3c134066eedL49-R49): Modified the `cv2.namedWindow` function to use `cv2.WINDOW_AUTOSIZE` for better window management.
* [`segment.py`](diffhunk://#diff-055f4e62558f5326938f7dbe96b8b8ac992924586b895304ef285ab27d2d49d9R90-R91): Added resizing of `mask` and `result` to match the desired width of 512 pixels.

Code simplification and cleanup:

* [`segment.py`](diffhunk://#diff-055f4e62558f5326938f7dbe96b8b8ac992924586b895304ef285ab27d2d49d9L114-L162): Removed redundant code for reading frames, converting to HSV, applying masks, and resizing frames. This simplifies the video processing loop and reduces potential errors.


## Type of Change
<!-- Mark with an 'x' the types of changes introduced in this PR -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Describe the tests that you ran to verify your changes -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Additional context(if any)**

# 🏆Are you contributing under any open-source program ?
Yes, Apertre2.0



