### PR TITLE
fix: Redundant Morphology Operations in apply_mask Function

### DIFF
--- a/img_segment.py
+++ b/img_segment.py
@@ -108,7 +108,7 @@ while True:
     # Adjust kernel size
     kernel_size = max(1, cv2.getTrackbarPos("K_Size", "Tracking"))
     kernel = np.ones((kernel_size, kernel_size), np.uint8)
-    result = cv2.morphologyEx(result, cv2.MORPH_OPEN, kernel)
+    mask, result = apply_mask(hsv_img, lower, upper, kernel_size=kernel_size)
 
     # Display results
     display_results(original=img_resized, mask=mask, result=result)

--- a/img_segment.py
+++ b/img_segment.py
@@ -108,7 +108,7 @@ while True:
     # Adjust kernel size
     kernel_size = max(1, cv2.getTrackbarPos("K_Size", "Tracking"))
     kernel = np.ones((kernel_size, kernel_size), np.uint8)
-    mask, result = apply_mask(hsv_img, lower, upper, kernel_size=kernel_size)
+    result = cv2.morphologyEx(result, cv2.MORPH_OPEN, kernel)
 
     # Display results
     display_results(original=img_resized, mask=mask, result=result)

--- a/segment.py
+++ b/segment.py
@@ -75,25 +75,25 @@ while True:
         # Get the current values of the trackbars (lower and upper bounds for segmentation)
         lower, upper = get_trackbar_values("Tracking")
 
-        # Handle hue wrapping for colors like red (where lower hue > upper hue)
-        if upper[0] < lower[0]:  # Handle hue wrapping case
-            mask1, result1 = apply_mask(hsv_frame, lower, np.array([179, upper[1], upper[2]]))
-            mask2, result2 = apply_mask(hsv_frame, np.array([0, lower[1], lower[2]]), upper)
-            mask = cv2.bitwise_or(mask1, mask2)  # Combine the two masks
-            result = cv2.bitwise_or(result1, result2)  # Combine the results
-        else:
-            mask, result = apply_mask(hsv_frame, lower, upper)
-
-        # Resize video frame to match desired width (e.g., width=512)
-        frame = resize_with_aspect_ratio(frame, width=512)
-        mask = cv2.resize(mask, (512, 512))
-        result = cv2.resize(result, (512, 512))
-
         # Adjustable Morphology Parameters: Dynamically adjust kernel size using trackbars
         kernel_size = cv2.getTrackbarPos("Kernel Size", "Tracking")  # Trackbar to control kernel size
         kernel_size = max(kernel_size, 1)  # Ensure kernel size is at least 1x1
         kernel = np.ones((kernel_size, kernel_size), np.uint8)  # Create a kernel of specified size
         result = cv2.morphologyEx(result, cv2.MORPH_OPEN, kernel)  # Apply opening (dilation + erosion)
+
+        # Handle hue wrapping for colors like red (where lower hue > upper hue)
+        if upper[0] < lower[0]:  # Handle hue wrapping case
+            mask1, result1 = apply_mask(hsv_frame, lower, np.array([179, upper[1], upper[2]]),kernel_size=kernel_size)
+            mask2, result2 = apply_mask(hsv_frame, np.array([0, lower[1], lower[2]]), upper,kernel_size=kernel_size)
+            mask = cv2.bitwise_or(mask1, mask2)  # Combine the two masks
+            result = cv2.bitwise_or(result1, result2)  # Combine the results
+        else:
+            mask, result = apply_mask(hsv_frame, lower, upper,kernel_size=kernel_size)
+
+        # Resize video frame to match desired width (e.g., width=512)
+        frame = resize_with_aspect_ratio(frame, width=512)
+        mask = cv2.resize(mask, (512, 512))
+        result = cv2.resize(result, (512, 512))
 
         # Display the original frame in the "Original" window
         cv2.imshow("Original", frame)

--- a/segment.py
+++ b/segment.py
@@ -75,11 +75,8 @@ while True:
         # Get the current values of the trackbars (lower and upper bounds for segmentation)
         lower, upper = get_trackbar_values("Tracking")
 
-        # Adjustable Morphology Parameters: Dynamically adjust kernel size using trackbars
         kernel_size = cv2.getTrackbarPos("Kernel Size", "Tracking")  # Trackbar to control kernel size
         kernel_size = max(kernel_size, 1)  # Ensure kernel size is at least 1x1
-        kernel = np.ones((kernel_size, kernel_size), np.uint8)  # Create a kernel of specified size
-        result = cv2.morphologyEx(result, cv2.MORPH_OPEN, kernel)  # Apply opening (dilation + erosion)
 
         # Handle hue wrapping for colors like red (where lower hue > upper hue)
         if upper[0] < lower[0]:  # Handle hue wrapping case
@@ -94,6 +91,10 @@ while True:
         frame = resize_with_aspect_ratio(frame, width=512)
         mask = cv2.resize(mask, (512, 512))
         result = cv2.resize(result, (512, 512))
+
+        # Adjustable Morphology Parameters: Dynamically adjust kernel size using trackbars
+        kernel = np.ones((kernel_size, kernel_size), np.uint8)  # Create a kernel of specified size
+        result = cv2.morphologyEx(result, cv2.MORPH_OPEN, kernel)  # Apply opening (dilation + erosion)
 
         # Display the original frame in the "Original" window
         cv2.imshow("Original", frame)
@@ -113,10 +114,10 @@ while True:
         print("Error: An unexpected error occurred during video processing. Check the log file for details.")
         
     # Convert mask to 3 channels before writing to video
-    mask_3ch = cv2.cvtColor(mask, cv2.COLOR_GRAY2BGR)
+    # mask_3ch = cv2.cvtColor(mask, cv2.COLOR_GRAY2BGR)
 
     # Get frame dimensions
-    frame_height, frame_width = mask.shape[:2]
+    # frame_height, frame_width = mask.shape[:2]
 
     # Display the original frame in the "Original" window
     cv2.imshow("Original", frame)

--- a/segmentation_utils.py
+++ b/segmentation_utils.py
@@ -100,14 +100,16 @@ def get_trackbar_values(window_name="Tracking"):
 
     return lower_bound, upper_bound
 
-def apply_mask(image, lower_bound, upper_bound):
+def apply_mask(image, lower_bound, upper_bound,  kernel_size=5):
     """Apply a mask to segment colors in the HSV range with noise reduction."""
     hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
     mask = cv2.inRange(hsv, lower_bound, upper_bound)
 
-    kernel = np.ones((5, 5), np.uint8)
-    mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)  
-    mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel) 
+    if kernel_size > 1:
+        kernel = np.ones((kernel_size, kernel_size), np.uint8)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)  
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel) 
+
     result = cv2.bitwise_and(image, image, mask=mask)
     return mask, result
 


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Redundant Morphology Operations in apply_mask Function

Closes #58 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->
This pull request includes several changes to improve the segmentation process by making kernel size adjustable through trackbars and ensuring consistent application of morphological transformations. The key changes involve modifying the `apply_mask` function to accept a dynamic kernel size and updating the segmentation logic to use this adjustable kernel size.

### Enhancements to segmentation process:

* [`img_segment.py`](diffhunk://#diff-edb8f3b129c3b13bb610448147a08d7f4a0807c43e57f02e5e75f3c134066eedL111-R111): Modified the segmentation process to use the `apply_mask` function with an adjustable kernel size, ensuring consistent application of morphological transformations.

* [`segment.py`](diffhunk://#diff-055f4e62558f5326938f7dbe96b8b8ac992924586b895304ef285ab27d2d49d9R78-L97): Added dynamic kernel size adjustment using trackbars and updated the segmentation logic to handle hue wrapping and apply masks with the adjustable kernel size.

* [`segmentation_utils.py`](diffhunk://#diff-64e13ceae04b5e0a87b33fd7a6a272ae70184ad0d5f483c0c6fe97f4c2778e84L103-R112): Updated the `apply_mask` function to accept a `kernel_size` parameter, allowing for dynamic adjustment of the kernel size used in morphological transformations.
