### PR TITLE
Fix hue blending in HSV palette display to handle circular wrap-around

### DIFF
--- a/palette.py
+++ b/palette.py
@@ -60,11 +60,18 @@ def draw_text_with_semi_transparent_bg(img, text, position, font_scale=0.7, colo
 
 
 def display_hsv_palette(img, l_h, l_s, l_v, u_h, u_s, u_v):
+     # Handle circular hue wrap-around
+    if l_h > u_h:
+        # Calculate the middle of the two ranges: (wraps around)
+        mid_hue = ((l_h + (u_h + 180)) // 2) % 180
+    else:
+        mid_hue = (l_h + u_h) // 2
+
     # Blend lower and upper HSV values
-    blended_h = (l_h + u_h) // 2
     blended_s = (l_s + u_s) // 2
     blended_v = (l_v + u_v) // 2
-    img[:] = [blended_h, blended_s, blended_v]
+
+    img[:] = [mid_hue, blended_s, blended_v]
     text_color = (255, 255, 255)
     draw_text_with_semi_transparent_bg(img, f"LH={l_h}, LS={l_s}, LV={l_v}", (20, 50), color=text_color)
     draw_text_with_semi_transparent_bg(img, f"UH={u_h}, US={u_s}, UV={u_v}", (20, 90), color=text_color)


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Fix hue blending in HSV palette display to handle circular wrap-around

Closes #75 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->
<html>
<body>
<!--StartFragment--><html><head></head><body><h3>📝 <strong>PR Description:</strong></h3>
<hr>
<h3>🔥 <strong>Description of the Issue</strong></h3>
<p>The previous HSV blending logic incorrectly calculated the mid-hue when the lower hue (<code inline="">LH</code>) value was greater than the upper hue (<code inline="">UH</code>). Since hue is circular (0-179), a simple average caused incorrect color representation. For example:</p>
<ul>
<li>
<p><code inline="">LH=170</code> and <code inline="">UH=10</code> incorrectly blended to <strong>90</strong> instead of properly wrapping around the color wheel.</p>
</li>
</ul>
<hr>
<h3>✅ <strong>Fix Implemented</strong></h3>
<ul>
<li>
<p>Added circular hue blending logic:</p>
<pre><code class="language-python">if l_h &gt; u_h:
    mid_hue = ((l_h + (u_h + 180)) // 2) % 180
else:
    mid_hue = (l_h + u_h) // 2
</code></pre>
</li>
<li>
<p>This ensures that hue values correctly wrap around the 0-179 range:</p>
<ul>
<li>
<p>When <code inline="">LH &gt; UH</code>: The code accounts for the hue range wrapping by adding 180 to the upper hue before averaging, then applying modulo 180 to keep it in the valid range.</p>
</li>
<li>
<p>When <code inline="">LH ≤ UH</code>: It performs a simple average.</p>
</li>
</ul>
</li>
</ul>
<hr>
<h3>🎯 <strong>Impact of the Fix</strong></h3>
<ul>
<li>
<p><strong>Accurate color representation</strong>: Properly blends hues that span the 0-179 boundary.</p>
</li>
<li>
<p><strong>Improved visualization</strong>: Users now see the expected blended hue, even when the range crosses the circular boundary.</p>
</li>
</ul>
</body>
</html>

