### PR TITLE
Fix/z order issue video

### DIFF
--- a/segment.py
+++ b/segment.py
@@ -63,6 +63,11 @@ def prompt_filename(title, default_name, filetypes):
     root = tk.Tk()
     root.withdraw()  
 
+    cv2.setWindowProperty("Tracking",cv2.WND_PROP_TOPMOST,0)
+    cv2.setWindowProperty("Original",cv2.WND_PROP_TOPMOST,0)
+    cv2.setWindowProperty("Mask",cv2.WND_PROP_TOPMOST,0)
+    cv2.setWindowProperty("Result",cv2.WND_PROP_TOPMOST,0)
+
     root.attributes('-topmost', True)  
     root.lift()  
     root.after(100,lambda: root.focus_force())
@@ -75,6 +80,10 @@ def prompt_filename(title, default_name, filetypes):
         print(f"Operation canceled. Using default filename: {default_name}")
         filename = default_name
 
+    cv2.setWindowProperty("Tracking",cv2.WND_PROP_TOPMOST,1)
+    cv2.setWindowProperty("Original",cv2.WND_PROP_TOPMOST,1)
+    cv2.setWindowProperty("Mask",cv2.WND_PROP_TOPMOST,1)
+    cv2.setWindowProperty("Result",cv2.WND_PROP_TOPMOST,1)
     root.destroy()  
     return filename
 

--- a/segment.py
+++ b/segment.py
@@ -68,10 +68,6 @@ def prompt_filename(title, default_name, filetypes):
     cv2.setWindowProperty("Mask",cv2.WND_PROP_TOPMOST,0)
     cv2.setWindowProperty("Result",cv2.WND_PROP_TOPMOST,0)
 
-    root.attributes('-topmost', True)  
-    root.lift()  
-    root.after(100,lambda: root.focus_force())
-
     filename = simpledialog.askstring(
         title, f"Enter filename for {title} (without extension):", initialvalue=default_name
     )


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : fix Z order issue in video segment

Closes #159 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->
This pull request includes changes to the `prompt_filename` function in the `segment.py` file to improve window management. The changes involve replacing the use of Tkinter with OpenCV for setting window properties.

Window management improvements:

* [`segment.py`](diffhunk://#diff-055f4e62558f5326938f7dbe96b8b8ac992924586b895304ef285ab27d2d49d9L66-R69): Replaced Tkinter's `attributes`, `lift`, and `focus_force` methods with OpenCV's `setWindowProperty` method to manage the "Tracking", "Original", "Mask", and "Result" windows.
* [`segment.py`](diffhunk://#diff-055f4e62558f5326938f7dbe96b8b8ac992924586b895304ef285ab27d2d49d9R79-R82): Added calls to OpenCV's `setWindowProperty` method to reset the "Tracking", "Original", "Mask", and "Result" windows to topmost after filename input.

# 📷 Screenshots
<!-- If applicable, add screenshots to help explain your problem. -->
Z order issue in video segment
![image](https://github.com/user-attachments/assets/e2840a70-e1db-457a-bf12-692b7cb8fe5d)
